### PR TITLE
Revert "Bump cryptography from 2.8 to 3.2 in /scripts"

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
-cryptography == 3.2
+cryptography == 2.8
 pyasn1_modules==0.1.5
 pytz==2018.9


### PR DESCRIPTION
Reverts kmwebnet/ECC608-Provision#2